### PR TITLE
Handle when target is not an object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ function assign(target/*, objects*/) {
   if (len === 1) {
     return target;
   }
+  if (!isObject(target)) {
+    return target;
+  }
   while (++i < len) {
     var val = arguments[i];
     if (isObject(val)) {
@@ -34,7 +37,7 @@ function extend(target, obj) {
 
   for (var key in obj) {
     if (hasOwn(obj, key)) {
-    var val = obj[key];
+      var val = obj[key];
       if (isObject(val)) {
         if (typeOf(target[key]) === 'undefined' && typeOf(val) === 'function') {
           target[key] = val;

--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ function assign(target/*, objects*/) {
   if (len === 1) {
     return target;
   }
-  if (!isObject(target)) {
-    return target;
-  }
   while (++i < len) {
     var val = arguments[i];
+    if (isPrimitive(target)) {
+      target = val;
+    }
     if (isObject(val)) {
       extend(target, val);
     }
@@ -57,6 +57,14 @@ function extend(target, obj) {
 
 function isObject(obj) {
   return typeOf(obj) === 'object' || typeOf(obj) === 'function';
+}
+
+/**
+ * Returns true if the val is a primitive (e.g. not a plain object, function or array)
+ */
+
+function isPrimitive(val) {
+  return !isObject(val) && !Array.isArray(val);
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -101,6 +101,13 @@ describe('assign', function() {
     assert.deepEqual(assign(one, two), {b: 5});
   });
 
+  it('should not overrite primitive values:', function() {
+    var one = {b: {c: {d: 'e', g: ['b']}}};
+    var two = {b: 5};
+    var three = {b: {c: {d: 'e', g: ['b']}}};
+    assert.deepEqual(assign(one, two, three), {b: 5});
+  });
+
   it('should assign null values:', function() {
     var one = {b: {c: {d: 'e', g: ['b']}}};
     var two = {b: null, c: null};

--- a/test.js
+++ b/test.js
@@ -101,11 +101,12 @@ describe('assign', function() {
     assert.deepEqual(assign(one, two), {b: 5});
   });
 
-  it('should not overrite primitive values:', function() {
+  it('should assign over primitive values:', function() {
     var one = {b: {c: {d: 'e', g: ['b']}}};
     var two = {b: 5};
-    var three = {b: {c: {d: 'e', g: ['b']}}};
-    assert.deepEqual(assign(one, two, three), {b: 5});
+    var three = {b: function() {}};
+    three.b.foo = 'bar';
+    assert.deepEqual(assign(one, two, three), three);
   });
 
   it('should assign null values:', function() {


### PR DESCRIPTION
@jonschlinkert Do you think it makes sense to do it this way where the `target` is returned, or does it make sense to merge the rest of the values and return the results?

The scenario that came up is that one of the tests in `templates` is using `engine`. The `pages` and `layouts` in the test have a `layout` property on the `data` object. There is also the built-in `layout` helper because of the `layout` template type being used in the test.

`engine` was attempting to merge an object that looked similar to this:

``` js
var ctx = { layout: 'a' };
var imports = { layout: function() { ... } };
ctx = assign({}, ctx, imports);
```

Since the function in the `imports` object had a property on it, the value of the `layout` in `ctx` (`'a'`) became the target and tried to assign properties from the function to the string.

This change will result in `ctx` looking like `{ layout: 'a' }`.

The other way we can do it is so `ctx` would look like this: `{ layout: function() { ... } }`.
