### PR TITLE
add guard to speed up sparse deep assigns

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function assign(target/*, objects*/) {
   }
   while (++i < len) {
     var val = arguments[i];
+    if (target === val) continue;
     if (isPrimitive(target)) {
       target = val;
     }

--- a/test.js
+++ b/test.js
@@ -324,3 +324,22 @@ describe('symbols', function() {
     });
   }
 });
+
+describe('performance', function() {
+  it('should not waste cycles assigning equal objects', function() {
+    var treeDepth = 18;
+    var moreTree = function(depthRemaining) {
+      var tree = {};
+      if (depthRemaining) {
+        tree.one = moreTree(depthRemaining - 1);
+        tree.two = moreTree(depthRemaining - 1);
+      }
+      return tree;
+    };
+    var treeRoot = moreTree(treeDepth);
+    var timeStart = new Date().getTime();
+    assign(treeRoot, treeRoot);
+    var timeEnd = new Date().getTime();
+    assert(timeEnd - timeStart < 5);
+  });
+});


### PR DESCRIPTION
If sub-objects of arguments to `assign-deep` are identical, `assign-deep` currently recursively assigns anyway.  This is needlessly slow for sparse assignments.  This PR puts a guard up that stops the recursive assignment of identical objects.

The test isn't very elegant.  I'm not sure if there's a better way, or even if it's worth the test.