### PR TITLE
ref(docs): Clarify usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ const locals = {
   }
 };
 
-console.log(assign(config, locals));
+assign(config, locals)
+console.log(config);
 // {
 //   admin: false,
 //   author: {


### PR DESCRIPTION
This change makes it more obvious that `assign` is modifying `config` in place.